### PR TITLE
rectify blast versions in software exercises 1.2,1.3 to match 1.1. 

### DIFF
--- a/docs/materials/software/part1-ex2-wrapper.md
+++ b/docs/materials/software/part1-ex2-wrapper.md
@@ -30,7 +30,7 @@ Our wrapper script will be a bash script that runs several commands.
         :::bash
         #!/bin/bash
         
-        ncbi-blast-2.12.0+/bin/blastx -db pdbaa/pdbaa -query mouse.fa -out results.txt 
+        ncbi-blast-2.13.0+/bin/blastx -db pdbaa/pdbaa -query mouse.fa -out results.txt 
 
 
 	!!! note 
@@ -52,7 +52,7 @@ We now need to make some changes to our submit file.
 1. Note that since the `blastx` program is no longer listed as the executable, it will be need to be included in `transfer_input_files`. Instead of transferring just that program, we will transfer the original downloaded `tar.gz` file. To achieve efficiency, we'll also transfer the <span style="color:BLUE">pdbaa database</span> as the original `tar.gz` file instead of as the unzipped folder: 
 
         :::console
-        transfer_input_files = pdbaa.tar.gz, mouse.fa, ncbi-blast-2.12.0+-x64-linux.tar.gz
+        transfer_input_files = pdbaa.tar.gz, mouse.fa, ncbi-blast-2.13.0+-x64-linux.tar.gz
 
 1. If you really want to be on top of things, look at the log file for the last exercise, and update your memory and disk requests to be just slightly above the actual "Usage" values in the log. 
 
@@ -72,10 +72,10 @@ Now that our database and BLAST software are being transferred to the job as `ta
         :::bash
         #!/bin/bash
         
-        tar -xzf ncbi-blast-2.12.0+-x64-linux.tar.gz 
+        tar -xzf ncbi-blast-2.13.0+-x64-linux.tar.gz 
         tar -xzf pdbaa.tar.gz
 
-        ncbi-blast-2.12.0+/bin/blastx -db pdbaa/pdbaa -query mouse.fa -out results2.txt
+        ncbi-blast-2.13.0+/bin/blastx -db pdbaa/pdbaa -query mouse.fa -out results2.txt
 
 1.  While not strictly necessary, it's a good idea to enable executable permissions on the wrapper script, like so: 
 

--- a/docs/materials/software/part1-ex3-arguments.md
+++ b/docs/materials/software/part1-ex3-arguments.md
@@ -64,7 +64,7 @@ and third arguments, respectively.  Thus, in  the main command of the script,
 replace the various names with these variables: 
 
         :::bash
-        ncbi-blast-2.12.0+/bin/blastx -db $1/$1 -query $2 -out $3
+        ncbi-blast-2.13.0+/bin/blastx -db $1/$1 -query $2 -out $3
 
 	> If your wrapper script is in a different language, you should use 
 	that language's syntax for reading in variables from the command line. 
@@ -85,12 +85,12 @@ One of the downsides of this approach, is that our command has become
 harder to read. The original script contains all the information at a glance:
 
 	:::bash
-	ncbi-blast-2.12.0+/bin/blastx -db pdbaa/pdbaa -query mouse.fa -out results2.txt
+	ncbi-blast-2.13.0+/bin/blastx -db pdbaa/pdbaa -query mouse.fa -out results2.txt
 
 But our new version is more cryptic -- what is `$1`?: 
 
 	:::bash
-	ncbi-blast-2.10.1+/bin/blastx -db $1 -query $2 -out $3
+	ncbi-blast-2.13.0+/bin/blastx -db $1 -query $2 -out $3
 
 One way to overcome this is to create our own variable names inside the wrapper 
 script and assign the argument values to them. Here is an example for our 
@@ -103,10 +103,10 @@ BLAST script:
 	INFILE=$2
 	OUTFILE=$3
 	
-	tar -xzf ncbi-blast-2.10.1+-x64-linux.tar.gz 
+	tar -xzf ncbi-blast-2.13.0+-x64-linux.tar.gz 
 	tar -xzf pdbaa.tar.gz
 
-	ncbi-blast-2.10.1+/bin/blastx -db $DATABASE/$DATABASE -query $INFILE -out $OUTFILE
+	ncbi-blast-2.13.0+/bin/blastx -db $DATABASE/$DATABASE -query $INFILE -out $OUTFILE
 
 Here, we are assigning the input arguments (`$1`, `$2` and `$3`) to new variable names, and 
 then using **those** names (`$DATABASE`, `$INFILE`, and `$OUTFILE`) in the command, 


### PR DESCRIPTION
For participant sanity, keep blast versions the same between software 1.1, 1.2, and 1.3. Makes copy and pasting semi-safe.