### PR TITLE
Update DAG etc. logs for workflows exercise

### DIFF
--- a/docs/materials/workflows/part1-ex1-simple-dag.md
+++ b/docs/materials/workflows/part1-ex1-simple-dag.md
@@ -9,7 +9,7 @@ status: testing
 
 # Workflows Exercise 1.1: Coordinating a Set of Jobs With a Simple DAG
 
-The objective of this exercise is to learn the very basics of running a set of jobs as a single DAG workflow. We'll 
+The objective of this exercise is to learn the very basics of running a set of jobs as a single DAG workflow. We'll
 first show what it looks like to submit a workflow that contains a single job..
 
 ## What is DAGMan?
@@ -55,14 +55,14 @@ In your first window, submit the DAG:
 ``` console
 username@learn $ condor_submit_dag simple.dag
 -----------------------------------------------------------------------
-File for submitting this DAG to Condor           : simple.dag.condor.sub
+File for submitting this DAG to HTCondor           : simple.dag.condor.sub
 Log of DAGMan debugging messages                 : simple.dag.dagman.out
-Log of Condor library output                     : simple.dag.lib.out
-Log of Condor library error messages             : simple.dag.lib.err
+Log of HTCondor library output                     : simple.dag.lib.out
+Log of HTCondor library error messages             : simple.dag.lib.err
 Log of the life of condor_dagman itself          : simple.dag.dagman.log
 
 Submitting job(s).
-1 job(s) submitted to cluster 61.
+1 job(s) submitted to cluster 236874.
 -----------------------------------------------------------------------
 ```
 
@@ -71,196 +71,235 @@ In the second window, check the queue (what you see may be slightly different):
 ``` console
 username@learn $ condor_q -nobatch -wide:80
 
--- Submitter: learn.chtc.wisc.edu : <128.104.100.55:9618?sock=28867_10e4_2> : learn.chtc.wisc.edu
- ID      OWNER            SUBMITTED     RUN_TIME ST PRI SIZE CMD               
-  61.0   roy             6/21 22:51   0+00:03:47 R  0   0.3  condor_dagman     
-  62.0   roy             6/21 22:51   0+00:00:03 R  0   0.7  simple 4 10      
+-- Schedd: learn.chtc.wisc.edu : <128.104.100.148:9618?... @ 07/27/22 14:53:44
+ ID        OWNER            SUBMITTED     RUN_TIME ST PRI SIZE CMD
+236874.0   username        7/27 14:53   0+00:00:13 R  0    0.4 condor_dagman -p
+236875.0   username        7/27 14:53   0+00:00:00 I  0    0.0 sleep 4
 
-2 jobs; 0 completed, 0 removed, 0 idle, 2 running, 0 held, 0 suspended
+2 jobs; 0 completed, 0 removed, 1 idle, 1 running, 0 held, 0 suspended
 ```
 
 In the third window, watch what DAGMan does (what you see may be slightly different):
 
 ``` console
 username@learn $ tail -f --lines=500 simple.dag.dagman.out
-6/21/12 22:51:13 Setting maximum accepts per cycle 8.
-06/21/12 22:51:13 ******************************************************
-06/21/12 22:51:13 ** condor_scheduniv_exec.61.0 (CONDOR_DAGMAN) STARTING UP
-06/21/12 22:51:13 ** /usr/bin/condor_dagman
-06/21/12 22:51:13 ** SubsystemInfo: name=DAGMAN type=DAGMAN(10) class=DAEMON(1)
-06/21/12 22:51:13 ** Configuration: subsystem:DAGMAN local:<NONE> class:DAEMON
-06/21/12 22:51:13 ** $CondorVersion: 7.7.6 Apr 16 2012 BuildID: 34175 PRE-RELEASE-UWCS $
-06/21/12 22:51:13 ** $CondorPlatform: x86_64_rhap_5.7 $
-06/21/12 22:51:13 ** PID = 5812
-06/21/12 22:51:13 ** Log last touched 6/21 22:51:00
-06/21/12 22:51:13 ******************************************************
-06/21/12 22:51:13 Using config source: /etc/condor/condor_config
-06/21/12 22:51:13 Using local config sources: 
-06/21/12 22:51:13    /etc/condor/config.d/00-chtc-global.conf
-06/21/12 22:51:13    /etc/condor/config.d/01-chtc-submit.conf
-06/21/12 22:51:13    /etc/condor/config.d/02-chtc-flocking.conf
-06/21/12 22:51:13    /etc/condor/config.d/03-chtc-jobrouter.conf
-06/21/12 22:51:13    /etc/condor/config.d/04-chtc-blacklist.conf
-06/21/12 22:51:13    /etc/condor/config.d/99-osg-ss-group.conf
-06/21/12 22:51:13    /etc/condor/config.d/99-roy-extras.conf
-06/21/12 22:51:13    /etc/condor/condor_config.local
-06/21/12 22:51:13 DaemonCore: command socket at <128.104.100.55:60417>
-06/21/12 22:51:13 DaemonCore: private command socket at <128.104.100.55:60417>
-06/21/12 22:51:13 Setting maximum accepts per cycle 8.
-06/21/12 22:51:13 DAGMAN_USE_STRICT setting: 0
-06/21/12 22:51:13 DAGMAN_VERBOSITY setting: 3
-06/21/12 22:51:13 DAGMAN_DEBUG_CACHE_SIZE setting: 5242880
-06/21/12 22:51:13 DAGMAN_DEBUG_CACHE_ENABLE setting: False
-06/21/12 22:51:13 DAGMAN_SUBMIT_DELAY setting: 0
-06/21/12 22:51:13 DAGMAN_MAX_SUBMIT_ATTEMPTS setting: 6
-06/21/12 22:51:13 DAGMAN_STARTUP_CYCLE_DETECT setting: False
-06/21/12 22:51:13 DAGMAN_MAX_SUBMITS_PER_INTERVAL setting: 5
-06/21/12 22:51:13 DAGMAN_USER_LOG_SCAN_INTERVAL setting: 5
-06/21/12 22:51:13 allow_events (DAGMAN_IGNORE_DUPLICATE_JOB_EXECUTION, DAGMAN_ALLOW_EVENTS) setting: 114
-06/21/12 22:51:13 DAGMAN_RETRY_SUBMIT_FIRST setting: True
-06/21/12 22:51:13 DAGMAN_RETRY_NODE_FIRST setting: False
-06/21/12 22:51:13 DAGMAN_MAX_JOBS_IDLE setting: 0
-06/21/12 22:51:13 DAGMAN_MAX_JOBS_SUBMITTED setting: 0
-06/21/12 22:51:15 DAGMAN_MAX_PRE_SCRIPTS setting: 0
-06/21/12 22:51:15 DAGMAN_MAX_POST_SCRIPTS setting: 0
-06/21/12 22:51:15 DAGMAN_ALLOW_LOG_ERROR setting: False
-06/21/12 22:51:15 DAGMAN_MUNGE_NODE_NAMES setting: True
-06/21/12 22:51:15 DAGMAN_PROHIBIT_MULTI_JOBS setting: False
-06/21/12 22:51:15 DAGMAN_SUBMIT_DEPTH_FIRST setting: False
-06/21/12 22:51:15 DAGMAN_ALWAYS_RUN_POST setting: True
-06/21/12 22:51:15 DAGMAN_ABORT_DUPLICATES setting: True
-06/21/12 22:51:15 DAGMAN_ABORT_ON_SCARY_SUBMIT setting: True
-06/21/12 22:51:15 DAGMAN_PENDING_REPORT_INTERVAL setting: 600
-06/21/12 22:51:15 DAGMAN_AUTO_RESCUE setting: True
-06/21/12 22:51:15 DAGMAN_MAX_RESCUE_NUM setting: 100
-06/21/12 22:51:15 DAGMAN_WRITE_PARTIAL_RESCUE setting: True
-06/21/12 22:51:15 DAGMAN_DEFAULT_NODE_LOG setting: null
-06/21/12 22:51:15 DAGMAN_GENERATE_SUBDAG_SUBMITS setting: True
-06/21/12 22:51:15 ALL_DEBUG setting: 
-06/21/12 22:51:15 DAGMAN_DEBUG setting: 
-06/21/12 22:51:15 argv[0] == "condor_scheduniv_exec.61.0"
-06/21/12 22:51:15 argv[1] == "-Lockfile"
-06/21/12 22:51:15 argv[2] == "simple.dag.lock"
-06/21/12 22:51:15 argv[3] == "-AutoRescue"
-06/21/12 22:51:15 argv[4] == "1"
-06/21/12 22:51:15 argv[5] == "-DoRescueFrom"
-06/21/12 22:51:15 argv[6] == "0"
-06/21/12 22:51:15 argv[7] == "-Dag"
-06/21/12 22:51:15 argv[8] == "simple.dag"
-06/21/12 22:51:15 argv[9] == "-CsdVersion"
-06/21/12 22:51:15 argv[10] == "$CondorVersion: 7.7.6 Apr 16 2012 BuildID: 34175 PRE-RELEASE-UWCS $"
-06/21/12 22:51:15 argv[11] == "-Force"
-06/21/12 22:51:15 argv[12] == "-Dagman"
-06/21/12 22:51:15 argv[13] == "/usr/bin/condor_dagman"
-06/21/12 22:51:15 Default node log file is: </home/roy/condor/simple.dag.nodes.log>
-06/21/12 22:51:15 DAG Lockfile will be written to simple.dag.lock
-06/21/12 22:51:15 DAG Input file is simple.dag
-06/21/12 22:51:15 Parsing 1 dagfiles
-06/21/12 22:51:15 Parsing simple.dag ...
-06/21/12 22:51:15 Dag contains 1 total jobs
-06/21/12 22:51:15 Sleeping for 12 seconds to ensure ProcessId uniqueness
-06/21/12 22:51:27 Bootstrapping...
-06/21/12 22:51:27 Number of pre-completed nodes: 0
-06/21/12 22:51:27 Registering condor_event_timer...
-06/21/12 22:51:28 Sleeping for one second for log file consistency
-06/21/12 22:51:29 MultiLogFiles: truncating log file /home/roy/condor/simple.log
-06/21/12 22:51:29 Submitting Condor Node Simple job(s)...
+07/27/22 14:53:31 (D_ALWAYS) ******************************************************
+07/27/22 14:53:31 (D_ALWAYS) ** condor_scheduniv_exec.236874.0 (CONDOR_DAGMAN) STARTING UP
+07/27/22 14:53:31 (D_ALWAYS) ** /usr/bin/condor_dagman
+07/27/22 14:53:31 (D_ALWAYS) ** SubsystemInfo: name=DAGMAN type=DAGMAN(9) class=CLIENT(2)
+07/27/22 14:53:31 (D_ALWAYS) ** Configuration: subsystem:DAGMAN local:<NONE> class:CLIENT
+07/27/22 14:53:31 (D_ALWAYS) ** $CondorVersion: 9.11.0 2022-07-19 BuildID: 597572 PackageID: 9.11.0-0.597572 RC $
+07/27/22 14:53:31 (D_ALWAYS) ** $CondorPlatform: x86_64_CentOS7 $
+07/27/22 14:53:31 (D_ALWAYS) ** PID = 1650410
+07/27/22 14:53:31 (D_ALWAYS) ** Log last touched time unavailable (No such file or directory)
+07/27/22 14:53:31 (D_ALWAYS) ******************************************************
+07/27/22 14:53:31 (D_ALWAYS) Using config source: /etc/condor/condor_config
+07/27/22 14:53:31 (D_ALWAYS) Using local config sources:
+07/27/22 14:53:31 (D_ALWAYS)    /var/run/condor/pids.conf
+07/27/22 14:53:31 (D_ALWAYS)    /var/run/condor/master_pid_6051.conf
+07/27/22 14:53:31 (D_ALWAYS)    /etc/condor/condor_config.principals
+07/27/22 14:53:31 (D_ALWAYS)    /etc/condor/condor_config.hosts
+07/27/22 14:53:31 (D_ALWAYS)    /etc/condor/condor_config.global
+07/27/22 14:53:31 (D_ALWAYS)    /etc/condor/condor_config.policy
+07/27/22 14:53:31 (D_ALWAYS)    /etc/condor/condor_config.x86_64_CentOS7
+07/27/22 14:53:31 (D_ALWAYS)    /etc/condor/condor_config.security
+07/27/22 14:53:31 (D_ALWAYS)    /etc/condor/hosts/learn.chtc.wisc.edu.local
+07/27/22 14:53:31 (D_ALWAYS)    /etc/condor/include/schedd.conf
+07/27/22 14:53:31 (D_ALWAYS)    /etc/condor/include/facility_wid.conf
+07/27/22 14:53:31 (D_ALWAYS)    /etc/condor/include/scitokens_credmon.conf
+07/27/22 14:53:31 (D_ALWAYS)    /etc/condor/include/owned_by_chtc.conf
+07/27/22 14:53:31 (D_ALWAYS)    /var/run/condor/condor_config.startd_offline_gpus
+07/27/22 14:53:31 (D_ALWAYS)    /etc/condor/condor_config.flightworthy_testing
+07/27/22 14:53:31 (D_ALWAYS) config Macros = 365, Sorted = 365, StringBytes = 85642, TablesBytes = 13292
+07/27/22 14:53:31 (D_ALWAYS) CLASSAD_CACHING is ENABLED
+07/27/22 14:53:31 (D_ALWAYS) Daemon Log is logging: D_ALWAYS D_ERROR D_STATUS
+07/27/22 14:53:31 (D_ALWAYS) DaemonCore: No command port requested.
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_USE_STRICT setting: 1
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_VERBOSITY setting: 3
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_DEBUG_CACHE_SIZE setting: 5242880
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_DEBUG_CACHE_ENABLE setting: False
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_SUBMIT_DELAY setting: 0
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_MAX_SUBMIT_ATTEMPTS setting: 6
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_STARTUP_CYCLE_DETECT setting: False
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_MAX_SUBMITS_PER_INTERVAL setting: 100
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_AGGRESSIVE_SUBMIT setting: False
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_USER_LOG_SCAN_INTERVAL setting: 5
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_QUEUE_UPDATE_INTERVAL setting: 300
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_DEFAULT_PRIORITY setting: 0
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_SUPPRESS_NOTIFICATION setting: True
+07/27/22 14:53:31 (D_ALWAYS) allow_events (DAGMAN_ALLOW_EVENTS) setting: 114
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_RETRY_SUBMIT_FIRST setting: True
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_RETRY_NODE_FIRST setting: False
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_MAX_JOBS_IDLE setting: 1000
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_MAX_JOBS_SUBMITTED setting: 0
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_MAX_PRE_SCRIPTS setting: 20
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_MAX_POST_SCRIPTS setting: 20
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_MAX_HOLD_SCRIPTS setting: 20
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_MUNGE_NODE_NAMES setting: True
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_PROHIBIT_MULTI_JOBS setting: False
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_SUBMIT_DEPTH_FIRST setting: False
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_ALWAYS_RUN_POST setting: False
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_CONDOR_SUBMIT_EXE setting: /usr/bin/condor_submit
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_USE_DIRECT_SUBMIT setting: True
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_DEFAULT_APPEND_VARS setting: False
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_ABORT_DUPLICATES setting: True
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_ABORT_ON_SCARY_SUBMIT setting: True
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_PENDING_REPORT_INTERVAL setting: 600
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_AUTO_RESCUE setting: True
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_MAX_RESCUE_NUM setting: 100
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_WRITE_PARTIAL_RESCUE setting: True
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_DEFAULT_NODE_LOG setting: @(DAG_DIR)/@(DAG_FILE).nodes.log
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_GENERATE_SUBDAG_SUBMITS setting: True
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_MAX_JOB_HOLDS setting: 100
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_HOLD_CLAIM_TIME setting: 20
+07/27/22 14:53:31 (D_ALWAYS) ALL_DEBUG setting: D_CAT
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_DEBUG setting:
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_SUPPRESS_JOB_LOGS setting: False
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_REMOVE_NODE_JOBS setting: True
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN will adjust edges after parsing
+07/27/22 14:53:31 (D_ALWAYS) argv[0] == "condor_scheduniv_exec.236874.0"
+07/27/22 14:53:31 (D_ALWAYS) argv[1] == "-Lockfile"
+07/27/22 14:53:31 (D_ALWAYS) argv[2] == "simple.dag.lock"
+07/27/22 14:53:31 (D_ALWAYS) argv[3] == "-AutoRescue"
+07/27/22 14:53:31 (D_ALWAYS) argv[4] == "1"
+07/27/22 14:53:31 (D_ALWAYS) argv[5] == "-DoRescueFrom"
+07/27/22 14:53:31 (D_ALWAYS) argv[6] == "0"
+07/27/22 14:53:31 (D_ALWAYS) argv[7] == "-Dag"
+07/27/22 14:53:31 (D_ALWAYS) argv[8] == "simple.dag"
+07/27/22 14:53:31 (D_ALWAYS) argv[9] == "-Suppress_notification"
+07/27/22 14:53:31 (D_ALWAYS) argv[10] == "-CsdVersion"
+07/27/22 14:53:31 (D_ALWAYS) argv[11] == "$CondorVersion: 9.11.0 2022-07-19 BuildID: 597572 PackageID: 9.11.0-0.597572 RC $"
+07/27/22 14:53:31 (D_ALWAYS) argv[12] == "-Dagman"
+07/27/22 14:53:31 (D_ALWAYS) argv[13] == "/usr/bin/condor_dagman"
+07/27/22 14:53:31 (D_ALWAYS) Workflow batch-id: <236874.0>
+07/27/22 14:53:31 (D_ALWAYS) Workflow batch-name: <simple.dag+236874>
+07/27/22 14:53:31 (D_ALWAYS) Workflow accounting_group: <>
+07/27/22 14:53:31 (D_ALWAYS) Workflow accounting_group_user: <>
+07/27/22 14:53:31 (D_ALWAYS) Warning: failed to get attribute DAGNodeName
+07/27/22 14:53:31 (D_ALWAYS) DAGMAN_LOG_ON_NFS_IS_ERROR setting: False
+07/27/22 14:53:31 (D_ALWAYS) Default node log file is: </home/username/osg/workflows/./simple.dag.nodes.log>
+07/27/22 14:53:31 (D_ALWAYS) DAG Lockfile will be written to simple.dag.lock
+07/27/22 14:53:31 (D_ALWAYS) DAG Input file is simple.dag
+07/27/22 14:53:31 (D_ALWAYS) Parsing 1 dagfiles
+07/27/22 14:53:31 (D_ALWAYS) Parsing simple.dag ...
+07/27/22 14:53:31 (D_ALWAYS) Adjusting edges
+07/27/22 14:53:31 (D_ALWAYS) Dag contains 1 total jobs
+07/27/22 14:53:31 (D_ALWAYS) Bootstrapping...
+07/27/22 14:53:31 (D_ALWAYS) Number of pre-completed nodes: 0
+07/27/22 14:53:31 (D_ALWAYS) MultiLogFiles: truncating log file /home/username/osg/workflows/./simple.dag.nodes.log
+07/27/22 14:53:31 (D_ALWAYS) DAG status: 0 (DAG_STATUS_OK)
+07/27/22 14:53:31 (D_ALWAYS) Of 1 nodes total:
+07/27/22 14:53:31 (D_ALWAYS)  Done     Pre   Queued    Post   Ready   Un-Ready   Failed
+07/27/22 14:53:31 (D_ALWAYS)   ===     ===      ===     ===     ===        ===      ===
+07/27/22 14:53:31 (D_ALWAYS)     0       0        0       0       1          0        0
+07/27/22 14:53:31 (D_ALWAYS) 0 job proc(s) currently held
+07/27/22 14:53:31 (D_ALWAYS) DAGMan Runtime Statistics: [ EventCycleTimeCount = 0.0; EventCycleTimeSum = 0.0; LogProcessCycleTimeCount = 0.0; LogProcessCycleTimeSum = 0.0; SleepCycleTimeCount = 0.0; SleepCycleTimeSum = 0.0; SubmitCycleTimeCount = 0.0; SubmitCycleTimeSum = 0.0; ]
+07/27/22 14:53:31 (D_ALWAYS) Registering condor_event_timer...
+07/27/22 14:53:32 (D_ALWAYS) Submitting HTCondor Node Simple job(s)...
 ```
 
 <span style="color:RED">**Here's where the job is submitted**</span>
 
 ```file
-06/21/12 22:51:29 submitting: condor_submit 
-                              -a dag_node_name' '=' 'Simple 
-                              -a +DAGManJobId' '=' '61 
-                              -a DAGManJobId' '=' '61 
-                              -a submit_event_notes' '=' 'DAG' 'Node:' 'Simple 
-                              -a DAG_STATUS' '=' '0 
-                              -a FAILED_COUNT' '=' '0 
-                              -a +DAGParentNodeNames' '=' '"" submit
-06/21/12 22:51:30 From submit: Submitting job(s).
-06/21/12 22:51:30 From submit: 1 job(s) submitted to cluster 62.
-06/21/12 22:51:30   assigned Condor ID (62.0.0)
-06/21/12 22:51:30 Just submitted 1 job this cycle...
-06/21/12 22:51:30 Currently monitoring 1 Condor log file(s)
-06/21/12 22:51:30 Event: ULOG_SUBMIT for Condor Node Simple (62.0.0)
-06/21/12 22:51:30 Number of idle job procs: 1
-06/21/12 22:51:30 Of 1 nodes total:
-06/21/12 22:51:30  Done     Pre   Queued    Post   Ready   Un-Ready   Failed
-06/21/12 22:51:30   ===     ===      ===     ===     ===        ===      ===
-06/21/12 22:51:30     0       0        1       0       0          0        0
-06/21/12 22:51:30 0 job proc(s) currently held
-06/21/12 22:55:05 Currently monitoring 1 Condor log file(s)
+07/27/22 14:53:32 (D_ALWAYS) Submitting node Simple from file simple.sub using direct job submission
+07/27/22 14:53:32 (D_ALWAYS) Submit warning: Submit:0:the line 'RETRY = 0' was unused by DAGMAN. Is it a typo?
+|Submit:0:the line 'JOB = Simple' was unused by DAGMAN. Is it a typo?
+07/27/22 14:53:32 (D_ALWAYS) 	assigned HTCondor ID (236875.0.0)
+07/27/22 14:53:32 (D_ALWAYS) Just submitted 1 job this cycle...
+07/27/22 14:53:32 (D_ALWAYS) DAG status: 0 (DAG_STATUS_OK)
+07/27/22 14:53:32 (D_ALWAYS) Of 1 nodes total:
+07/27/22 14:53:32 (D_ALWAYS)  Done     Pre   Queued    Post   Ready   Un-Ready   Failed
+07/27/22 14:53:32 (D_ALWAYS)   ===     ===      ===     ===     ===        ===      ===
+07/27/22 14:53:32 (D_ALWAYS)     0       0        1       0       0          0        0
+07/27/22 14:53:32 (D_ALWAYS) 0 job proc(s) currently held
+07/27/22 14:53:32 (D_ALWAYS) DAGMan Runtime Statistics: [ EventCycleTimeCount = 0.0; EventCycleTimeSum = 0.0; LogProcessCycleTimeCount = 0.0; LogProcessCycleTimeSum = 0.0; SleepCycleTimeCount = 0.0; SleepCycleTimeSum = 0.0; SubmitCycleTimeAvg = 0.05731511116027832; SubmitCycleTimeCount = 1.0; SubmitCycleTimeMax = 0.05731511116027832; SubmitCycleTimeMin = 0.05731511116027832; SubmitCycleTimeStd = 0.05731511116027832; SubmitCycleTimeSum = 0.05731511116027832; ]
+07/27/22 14:53:37 (D_ALWAYS) Currently monitoring 1 HTCondor log file(s)
 ```
 
 <span style="color:RED">**Here's where DAGMan noticed that the job is running**</span>
 
 ```file
-06/21/12 22:55:05 Event: ULOG_EXECUTE for Condor Node Simple (62.0.0)
-06/21/12 22:55:05 Number of idle job procs: 0
-06/21/12 22:55:10 Currently monitoring 1 Condor log file(s)
-06/21/12 22:55:10 Event: ULOG_IMAGE_SIZE for Condor Node Simple (62.0.0)
-06/21/12 22:56:05 Currently monitoring 1 Condor log file(s)
-06/21/12 22:56:05 Event: ULOG_IMAGE_SIZE for Condor Node Simple (62.0.0)
+07/27/22 14:55:22 (D_ALWAYS) Event: ULOG_EXECUTE for HTCondor Node Simple (236875.0.0) {07/27/22 14:55:18}
+07/27/22 14:55:22 (D_ALWAYS) Number of idle job procs: 0
 ```
 
 <span style="color:RED">**Here's where DAGMan noticed that the job finished.**</span>
 
 ```file
-06/21/12 22:56:05 Event: ULOG_JOB_TERMINATED for Condor Node Simple (62.0.0)
-06/21/12 22:56:05 Node Simple job proc (62.0.0) completed successfully.
-06/21/12 22:56:05 Node Simple job completed
-06/21/12 22:56:05 Number of idle job procs: 0
-06/21/12 22:56:05 Of 1 nodes total:
-06/21/12 22:56:05  Done     Pre   Queued    Post   Ready   Un-Ready   Failed
-06/21/12 22:56:05   ===     ===      ===     ===     ===        ===      ===
-06/21/12 22:56:05     1       0        0       0       0          0        0
-06/21/12 22:56:05 0 job proc(s) currently held
+07/27/22 14:55:22 (D_ALWAYS) Event: ULOG_JOB_TERMINATED for HTCondor Node Simple (236875.0.0) {07/27/22 14:55:22}
+07/27/22 14:55:22 (D_ALWAYS) Number of idle job procs: 0
+07/27/22 14:55:22 (D_ALWAYS) Node Simple job proc (236875.0.0) completed successfully.
+07/27/22 14:55:22 (D_ALWAYS) Node Simple job completed
+07/27/22 14:55:22 (D_ALWAYS) DAG status: 0 (DAG_STATUS_OK)
+07/27/22 14:55:22 (D_ALWAYS) Of 1 nodes total:
+07/27/22 14:55:22 (D_ALWAYS)  Done     Pre   Queued    Post   Ready   Un-Ready   Failed
+07/27/22 14:55:22 (D_ALWAYS)   ===     ===      ===     ===     ===        ===      ===
+07/27/22 14:55:22 (D_ALWAYS)     1       0        0       0       0          0        0
+07/27/22 14:55:22 (D_ALWAYS) 0 job proc(s) currently held
+07/27/22 14:55:22 (D_ALWAYS) DAGMan Runtime Statistics: [ EventCycleTimeAvg = 0.002710472453724254; EventCycleTimeCount = 22.0; EventCycleTimeMax = 0.05800700187683105; EventCycleTimeMin = 3.695487976074219E-05; EventCycleTimeStd = 0.01235157343544432; EventCycleTimeSum = 0.05963039398193359; LogProcessCycleTimeAvg = 0.0008540153503417969; LogProcessCycleTimeCount = 2.0; LogProcessCycleTimeMax = 0.0009989738464355469; LogProcessCycleTimeMin = 0.0007090568542480469; LogProcessCycleTimeStd = 0.0002050022711569886; LogProcessCycleTimeSum = 0.001708030700683594; SleepCycleTimeAvg = 5.00527053529566; SleepCycleTimeCount = 22.0; SleepCycleTimeMax = 5.005910873413086; SleepCycleTimeMin = 5.00182318687439; SleepCycleTimeStd = 0.0007872599017242631; SleepCycleTimeSum = 110.1159517765045; SubmitCycleTimeAvg = 0.002509210420691449; SubmitCycleTimeCount = 23.0; SubmitCycleTimeMax = 0.05731511116027832; SubmitCycleTimeMin = 1.382827758789062E-05; SubmitCycleTimeStd = 0.01194727151749822; SubmitCycleTimeSum = 0.05771183967590332; ]
 ```
 
 <span style="color:RED">**Here's where DAGMan noticed that all the work is done.**</span>
 
 ```file
-06/21/12 22:56:05 All jobs Completed!
-06/21/12 22:56:05 Note: 0 total job deferrals because of -MaxJobs limit (0)
-06/21/12 22:56:05 Note: 0 total job deferrals because of -MaxIdle limit (0)
-06/21/12 22:56:05 Note: 0 total job deferrals because of node category throttles
-06/21/12 22:56:05 Note: 0 total PRE script deferrals because of -MaxPre limit (0)
-06/21/12 22:56:05 Note: 0 total POST script deferrals because of -MaxPost limit (0)
-06/21/12 22:56:05 **** condor_scheduniv_exec.61.0 (condor_DAGMAN) pid 5812 EXITING WITH STATUS 0
+07/27/22 14:55:22 (D_ALWAYS) All jobs Completed!
+07/27/22 14:55:22 (D_ALWAYS) Note: 0 total job deferrals because of -MaxJobs limit (0)
+07/27/22 14:55:22 (D_ALWAYS) Note: 0 total job deferrals because of -MaxIdle limit (1000)
+07/27/22 14:55:22 (D_ALWAYS) Note: 0 total job deferrals because of node category throttles
+07/27/22 14:55:22 (D_ALWAYS) Note: 0 total PRE script deferrals because of -MaxPre limit (20) or DEFER
+07/27/22 14:55:22 (D_ALWAYS) Note: 0 total POST script deferrals because of -MaxPost limit (20) or DEFER
+07/27/22 14:55:22 (D_ALWAYS) Note: 0 total HOLD script deferrals because of -MaxHold limit (20) or DEFER
+07/27/22 14:55:22 (D_ALWAYS) DAG status: 0 (DAG_STATUS_OK)
+07/27/22 14:55:22 (D_ALWAYS) Of 1 nodes total:
+07/27/22 14:55:22 (D_ALWAYS)  Done     Pre   Queued    Post   Ready   Un-Ready   Failed
+07/27/22 14:55:22 (D_ALWAYS)   ===     ===      ===     ===     ===        ===      ===
+07/27/22 14:55:22 (D_ALWAYS)     1       0        0       0       0          0        0
+07/27/22 14:55:22 (D_ALWAYS) 0 job proc(s) currently held
+07/27/22 14:55:22 (D_ALWAYS) DAGMan Runtime Statistics: [ EventCycleTimeAvg = 0.002710472453724254; EventCycleTimeCount = 22.0; EventCycleTimeMax = 0.05800700187683105; EventCycleTimeMin = 3.695487976074219E-05; EventCycleTimeStd = 0.01235157343544432; EventCycleTimeSum = 0.05963039398193359; LogProcessCycleTimeAvg = 0.0008540153503417969; LogProcessCycleTimeCount = 2.0; LogProcessCycleTimeMax = 0.0009989738464355469; LogProcessCycleTimeMin = 0.0007090568542480469; LogProcessCycleTimeStd = 0.0002050022711569886; LogProcessCycleTimeSum = 0.001708030700683594; SleepCycleTimeAvg = 5.00527053529566; SleepCycleTimeCount = 22.0; SleepCycleTimeMax = 5.005910873413086; SleepCycleTimeMin = 5.00182318687439; SleepCycleTimeStd = 0.0007872599017242631; SleepCycleTimeSum = 110.1159517765045; SubmitCycleTimeAvg = 0.002509210420691449; SubmitCycleTimeCount = 23.0; SubmitCycleTimeMax = 0.05731511116027832; SubmitCycleTimeMin = 1.382827758789062E-05; SubmitCycleTimeStd = 0.01194727151749822; SubmitCycleTimeSum = 0.05771183967590332; ]
+07/27/22 14:55:22 (D_ALWAYS) Wrote metrics file simple.dag.metrics.
+07/27/22 14:55:22 (D_ALWAYS) DAGMan Runtime Statistics: [ EventCycleTimeAvg = 0.002710472453724254; EventCycleTimeCount = 22.0; EventCycleTimeMax = 0.05800700187683105; EventCycleTimeMin = 3.695487976074219E-05; EventCycleTimeStd = 0.01235157343544432; EventCycleTimeSum = 0.05963039398193359; LogProcessCycleTimeAvg = 0.0008540153503417969; LogProcessCycleTimeCount = 2.0; LogProcessCycleTimeMax = 0.0009989738464355469; LogProcessCycleTimeMin = 0.0007090568542480469; LogProcessCycleTimeStd = 0.0002050022711569886; LogProcessCycleTimeSum = 0.001708030700683594; SleepCycleTimeAvg = 5.00527053529566; SleepCycleTimeCount = 22.0; SleepCycleTimeMax = 5.005910873413086; SleepCycleTimeMin = 5.00182318687439; SleepCycleTimeStd = 0.0007872599017242631; SleepCycleTimeSum = 110.1159517765045; SubmitCycleTimeAvg = 0.002509210420691449; SubmitCycleTimeCount = 23.0; SubmitCycleTimeMax = 0.05731511116027832; SubmitCycleTimeMin = 1.382827758789062E-05; SubmitCycleTimeStd = 0.01194727151749822; SubmitCycleTimeSum = 0.05771183967590332; ]
+07/27/22 14:55:22 (D_ALWAYS) **** condor_scheduniv_exec.236874.0 (condor_DAGMAN) pid 1650410 EXITING WITH STATUS 0
 ```
 
 Now verify your results:
 
 ``` console
 username@learn $ cat simple.log
-000 (062.000.000) 06/21 22:51:30 Job submitted from host: <128.104.100.55:9618?sock=28867_10e4_2>
+000 (236875.000.000) 2022-07-27 14:53:32 Job submitted from host: <128.104.100.148:9618?addrs=128.104.100.148-9618+[2607-f388-107c-501-216-3eff-feb2-bc11]-9618&alias=learn.chtc.wisc.edu&noUDP&sock=schedd_6051_0fa9>
     DAG Node: Simple
 ...
-001 (062.000.000) 06/21 22:55:00 Job executing on host: <128.104.58.36:46761>
+040 (236875.000.000) 2022-07-27 14:55:17 Started transferring input files
+	Transferring to host: <128.104.58.123:9618?addrs=128.104.58.123-9618+[2607-f388-1086-0-67d-7bff-fe41-62ea]-9618&alias=e1540.chtc.wisc.edu&noUDP&sock=slot1_4_9756_bc06_56915>
 ...
-006 (062.000.000) 06/21 22:55:09 Image size of job updated: 750
-    3  -  MemoryUsage of job (MB)
-    2324  -  ResidentSetSize of job (KB)
+040 (236875.000.000) 2022-07-27 14:55:17 Finished transferring input files
 ...
-006 (062.000.000) 06/21 22:56:00 Image size of job updated: 780
-    3  -  MemoryUsage of job (MB)
-    2324  -  ResidentSetSize of job (KB)
+001 (236875.000.000) 2022-07-27 14:55:18 Job executing on host: <128.104.58.123:9618?addrs=128.104.58.123-9618+[2607-f388-1086-0-67d-7bff-fe41-62ea]-9618&alias=e1540.chtc.wisc.edu&noUDP&sock=startd_7130_2a59>
 ...
-005 (062.000.000) 06/21 22:56:00 Job terminated.
-    (1) Normal termination (return value 0)
-        Usr 0 00:00:00, Sys 0 00:00:00  -  Run Remote Usage
-        Usr 0 00:00:00, Sys 0 00:00:00  -  Run Local Usage
-        Usr 0 00:00:00, Sys 0 00:00:00  -  Total Remote Usage
-        Usr 0 00:00:00, Sys 0 00:00:00  -  Total Local Usage
-    57  -  Run Bytes Sent By Job
-    608490  -  Run Bytes Received By Job
-    57  -  Total Bytes Sent By Job
-    608490  -  Total Bytes Received By Job
-    Partitionable Resources :    Usage  Request          
-       Cpus                 :                 1          
-       Disk (KB)            :      750      750          
-       Memory (MB)          :        3        3          
+006 (236875.000.000) 2022-07-27 14:55:22 Image size of job updated: 35
+	0  -  MemoryUsage of job (MB)
+	0  -  ResidentSetSize of job (KB)
+...
+040 (236875.000.000) 2022-07-27 14:55:22 Started transferring output files
+...
+040 (236875.000.000) 2022-07-27 14:55:22 Finished transferring output files
+...
+005 (236875.000.000) 2022-07-27 14:55:22 Job terminated.
+	(1) Normal termination (return value 0)
+		Usr 0 00:00:00, Sys 0 00:00:00  -  Run Remote Usage
+		Usr 0 00:00:00, Sys 0 00:00:00  -  Run Local Usage
+		Usr 0 00:00:00, Sys 0 00:00:00  -  Total Remote Usage
+		Usr 0 00:00:00, Sys 0 00:00:00  -  Total Local Usage
+	0  -  Run Bytes Sent By Job
+	33128  -  Run Bytes Received By Job
+	0  -  Total Bytes Sent By Job
+	33128  -  Total Bytes Received By Job
+	Partitionable Resources :    Usage  Request Allocated
+	   Cpus                 :                 1         1
+	   Disk (KB)            :       49  1048576   1336536
+	   IoHeavy              :                           0
+	   Memory (MB)          :        0     1024      1024
+
+	Job terminated of its own accord at 2022-07-27T19:55:22Z with exit-code 0.
 ...
 ```
 
@@ -268,29 +307,29 @@ Looking at DAGMan's various files, we see that DAGMan itself ran as a job (speci
 
 ``` console
 username@learn $ ls simple.dag.*
-simple.dag.condor.sub  simple.dag.dagman.log  simple.dag.dagman.out  simple.dag.lib.err  simple.dag.lib.out 
+simple.dag.condor.sub  simple.dag.dagman.out  simple.dag.lib.out  simple.dag.nodes.log
+simple.dag.dagman.log  simple.dag.lib.err     simple.dag.metrics
 
 username@learn $ cat simple.dag.condor.sub
 # Filename: simple.dag.condor.sub
-# Generated by condor_submit_dag simple.dag 
-universe    = scheduler
-executable  = /usr/bin/condor_dagman
-getenv      = True
-output      = simple.dag.lib.out
-error       = simple.dag.lib.err
-log     = simple.dag.dagman.log
-remove_kill_sig = SIGUSR1
-+OtherJobRemoveRequirements = "DAGManJobId == $(cluster)"
+# Generated by condor_submit_dag simple.dag
+universe	= scheduler
+executable	= /usr/bin/condor_dagman
+getenv		= True
+output		= simple.dag.lib.out
+error		= simple.dag.lib.err
+log		= simple.dag.dagman.log
+remove_kill_sig	= SIGUSR1
++OtherJobRemoveRequirements	= "DAGManJobId =?= $(cluster)"
 # Note: default on_exit_remove expression:
 # ( ExitSignal =?= 11 || (ExitCode =!= UNDEFINED && ExitCode >=0 && ExitCode <= 2))
 # attempts to ensure that DAGMan is automatically
 # requeued by the schedd if it exits abnormally or
 # is killed (e.g., during a reboot).
-on_exit_remove  = ( ExitSignal =?= 11 || (ExitCode =!= UNDEFINED && ExitCode >=0 && ExitCode <= 2))
-copy_to_spool   = False
-arguments   = "-f -l . -Lockfile simple.dag.lock -AutoRescue 1 -DoRescueFrom 0 -Dag simple.dag 
-                              -CsdVersion $CondorVersion:' '7.7.6' 'Apr' '16' '2012' 'BuildID:' '34175' 'PRE-RELEASE-UWCS' '$ -Force -Dagman /usr/bin/condor_dagman"
-environment = _CONDOR_DAGMAN_LOG=simple.dag.dagman.out;_CONDOR_MAX_DAGMAN_LOG=0
+on_exit_remove	= (ExitSignal =?= 11 || (ExitCode =!= UNDEFINED && ExitCode >=0 && ExitCode <= 2))
+copy_to_spool	= False
+arguments	= "-p 0 -f -l . -Lockfile simple.dag.lock -AutoRescue 1 -DoRescueFrom 0 -Dag simple.dag -Suppress_notification -CsdVersion $CondorVersion:' '9.11.0' '2022-07-19' 'BuildID:' '597572' 'PackageID:' '9.11.0-0.597572' 'RC' '$ -Dagman /usr/bin/condor_dagman"
+environment	= _CONDOR_SCHEDD_ADDRESS_FILE=/var/lib/condor/spool/.schedd_address;_CONDOR_MAX_DAGMAN_LOG=0;_CONDOR_SCHEDD_DAEMON_AD_FILE=/var/lib/condor/spool/.schedd_classad;_CONDOR_DAGMAN_LOG=simple.dag.dagman.out
 queue
 ```
 

--- a/docs/materials/workflows/part1-ex2-mandelbrot.md
+++ b/docs/materials/workflows/part1-ex2-mandelbrot.md
@@ -47,8 +47,8 @@ The Mandelbrot set can take a while to create, particularly if you make the iter
 
         :::console
         username@learn $ goatbrot -i 1000 -o tile_000000_000000.ppm -c -0.75,0.75 -w 1.5 -s 500,500
-        username@learn $ goatbrot -i 1000 -o tile_000000_000001.ppm -c 0.75,0.75 -w 1.5 -s 500,500 
-        username@learn $ goatbrot -i 1000 -o tile_000001_000000.ppm -c -0.75,-0.75 -w 1.5 -s 500,500 
+        username@learn $ goatbrot -i 1000 -o tile_000000_000001.ppm -c 0.75,0.75 -w 1.5 -s 500,500
+        username@learn $ goatbrot -i 1000 -o tile_000001_000000.ppm -c -0.75,-0.75 -w 1.5 -s 500,500
         username@learn $ goatbrot -i 1000 -o tile_000001_000001.ppm -c 0.75,-0.75 -w 1.5 -s 500,500
 
 1.  Stitch the small images together into the complete image (in JPEG format):
@@ -61,16 +61,16 @@ This will produce the same image as above. We divided the image space into a 2×
 View the Image!
 ---------------
 
-Run the commands above so that you have the Mandelbrot image. 
-When you create the image, you might wonder how you can view it. 
+Run the commands above so that you have the Mandelbrot image.
+When you create the image, you might wonder how you can view it.
 If you're comfortable with `scp` or another method, you can copy it back to your computer to view it. Otherwise you can view it in your web browser in three easy steps:
 
 1.  Make your web directory (you only need to do this once):
 
         :::console
         username@learn $ cd ~
-        username@learn $ mkdir public_html 
-        username@learn $ chmod 0711 . 
+        username@learn $ mkdir public_html
+        username@learn $ chmod 0711 .
         username@learn $ chmod 0755 public_html
 
 1.  Copy the image into your web directory (the below command assumes you're back in the directory where you created mandel.jpg):
@@ -78,6 +78,6 @@ If you're comfortable with `scp` or another method, you can copy it back to your
         :::console
         username@learn $ cp mandel.jpg ~/public_html/
 
-1.  Access `http://learn.chtc.wisc.edu/~<USERNAME>/mandel.jpg` in your web browser (change <span style="color:RED">&lt;USERNAME&gt;</span> to your username on `learn.chtc.wisc.edu`, keeping the `~`).
+1.  Access `http://learn.chtc.wisc.edu/~<USERNAME>/mandel.jpg` in your web browser (be sure to use "http://" and change <span style="color:RED">&lt;USERNAME&gt;</span> to your username on `learn.chtc.wisc.edu`, keeping the `~`).
 
 

--- a/docs/materials/workflows/part1-ex3-complex-dag.md
+++ b/docs/materials/workflows/part1-ex3-complex-dag.md
@@ -113,15 +113,14 @@ Submit your DAG:
 ``` console
 username@learn $ condor_submit_dag goatbrot.dag
 -----------------------------------------------------------------------
-File for submitting this DAG to Condor           : goatbrot.dag.condor.sub
+File for submitting this DAG to HTCondor           : goatbrot.dag.condor.sub
 Log of DAGMan debugging messages                 : goatbrot.dag.dagman.out
-Log of Condor library output                     : goatbrot.dag.lib.out
-Log of Condor library error messages             : goatbrot.dag.lib.err
+Log of HTCondor library output                     : goatbrot.dag.lib.out
+Log of HTCondor library error messages             : goatbrot.dag.lib.err
 Log of the life of condor_dagman itself          : goatbrot.dag.dagman.log
 
 Submitting job(s).
-1 job(s) submitted to cluster 71.
-
+1 job(s) submitted to cluster 236879.
 -----------------------------------------------------------------------
 ```
 
@@ -133,68 +132,68 @@ Let’s follow the progress of the whole DAG:
 1.  Use the `condor_watch_q` command to keep an eye on the running jobs. See more information about this tool [here](https://htcondor.readthedocs.io/en/latest/man-pages/condor_watch_q.html).
 
         :::console
-        username@learn $ condor_watch_q 
+        username@learn $ condor_watch_q
 
-    <span style="color:RED">**If you're quick enough, you may have seen DAGMan running as the lone job, before it submitted additional job nodes:**</span> 
+    <span style="color:RED">**If you're quick enough, you may have seen DAGMan running as the lone job, before it submitted additional job nodes:**</span>
 
         :::console
         BATCH                IDLE  RUN  DONE  TOTAL  JOB_IDS
-        goatbrot.dag+222059     -    1     -      1  222059.0
+        goatbrot.dag+236879     -    1     -      1  236879.0
 
         [=============================================================================]
 
         Total: 1 jobs; 1 running
 
-        Updated at 2021-07-28 13:52:57
+        Updated at 2022-07-27 15:06:52
 
     <span style="color:RED">**DAGMan has submitted the goatbrot jobs, but they haven't started running yet**</span>
-    
+
         :::console
         BATCH                IDLE  RUN  DONE  TOTAL  JOB_IDS
-        goatbrot.dag+222059     4    1     -      5  222059.0 ... 222063.0
+        goatbrot.dag+236879     4    1     -      5  236879.0 ... 236883.0
 
         [===============--------------------------------------------------------------]
 
         Total: 5 jobs; 4 idle, 1 running
 
-        Updated at 2021-07-28 13:53:53
+        Updated at 2022-07-27 15:07:45
 
 
-    <span style="color:RED">**They're running**</span> 
+    <span style="color:RED">**They're running**</span>
 
         :::console
         BATCH                IDLE  RUN  DONE  TOTAL  JOB_IDS
-        goatbrot.dag+222059     -    5     -      5  222059.0 ... 222063.0
+        goatbrot.dag+236879     -    5     -      5  236879.0 ... 236883.0
         [=============================================================================]
 
         Total: 5 jobs; 5 running
 
-        Updated at 2021-07-28 13:54:33
+        Updated at 2022-07-27 15:08:48
 
     <span style="color:RED">**They finished, but DAGMan hasn't noticed yet. It only checks periodically:**</span>
 
         :::console
         BATCH                IDLE  RUN  DONE  TOTAL  JOB_IDS
-        goatbrot.dag+222059     -    1    4     -      5  222059.0 ... 222063.0
+        goatbrot.dag+236879     -    1    4     -      5  236879.0 ... 236883.0
 
         [##############################################################===============]
 
         Total: 5 jobs; 4 completed, 1 running
 
-        Updated at 2021-07-28 13:55:13
+        Updated at 2022-07-27 15:09:54
 
     Eventually, you'll see the montage job submitted, then running, then leave the queue, and then DAGMan will leave the queue.
 
 1.  Examine your results. For some reason, goatbrot prints everything to stderr, not stdout.
 
         :::console
-        username@learn $ cat goatbrot.err.0.0 
+        username@learn $ cat goatbrot.err.0.0
         Complex image: Center: -0.75 + 0.75i Width: 1.5 Height: 1.5 Upper Left: -1.5 + 1.5i Lower Right: 0 + 0i
-         
+
         Output image: Filename: tile_0_0.ppm Width, Height: 500, 500 Theme: beej Antialiased: no
-        
+
         Mandelbrot: Max Iterations: 100000 Continuous: no
-         
+
         Goatbrot: Multithreading: not supported in this build
 
         Completed: 100.0%

--- a/docs/materials/workflows/part1-ex4-failed-dag.md
+++ b/docs/materials/workflows/part1-ex4-failed-dag.md
@@ -35,64 +35,97 @@ Submit the DAG again:
 ``` console
 username@learn $ condor_submit_dag goatbrot.dag
 -----------------------------------------------------------------------
-File for submitting this DAG to Condor           : goatbrot.dag.condor.sub
+File for submitting this DAG to HTCondor           : goatbrot.dag.condor.sub
 Log of DAGMan debugging messages                 : goatbrot.dag.dagman.out
-Log of Condor library output                     : goatbrot.dag.lib.out
-Log of Condor library error messages             : goatbrot.dag.lib.err
+Log of HTCondor library output                     : goatbrot.dag.lib.out
+Log of HTCondor library error messages             : goatbrot.dag.lib.err
 Log of the life of condor_dagman itself          : goatbrot.dag.dagman.log
 
 Submitting job(s).
-1 job(s) submitted to cluster 77.
+1 job(s) submitted to cluster 236889.
 -----------------------------------------------------------------------
 ```
 
 Use watch to watch the jobs until they finish. In a separate window, use `tail --lines=500 -f goatbrot.dag.dagman.out` to watch what DAGMan does.
 
 ``` console
-06/22/12 17:57:41 Setting maximum accepts per cycle 8.
-06/22/12 17:57:41 ******************************************************
-06/22/12 17:57:41 ** condor_scheduniv_exec.77.0 (CONDOR_DAGMAN) STARTING UP
-06/22/12 17:57:41 ** /usr/bin/condor_dagman
-06/22/12 17:57:41 ** SubsystemInfo: name=DAGMAN type=DAGMAN(10) class=DAEMON(1)
-06/22/12 17:57:41 ** Configuration: subsystem:DAGMAN local:<NONE> class:DAEMON
-06/22/12 17:57:41 ** $CondorVersion: 7.7.6 Apr 16 2012 BuildID: 34175 PRE-RELEASE-UWCS $
-06/22/12 17:57:41 ** $CondorPlatform: x86_64_rhap_5.7 $
-06/22/12 17:57:41 ** PID = 26867
-06/22/12 17:57:41 ** Log last touched time unavailable (No such file or directory)
-06/22/12 17:57:41 ******************************************************
-06/22/12 17:57:41 Using config source: /etc/condor/condor_config
-06/22/12 17:57:41 Using local config sources: 
-06/22/12 17:57:41    /etc/condor/config.d/00-chtc-global.conf
-06/22/12 17:57:41    /etc/condor/config.d/01-chtc-submit.conf
-06/22/12 17:57:41    /etc/condor/config.d/02-chtc-flocking.conf
-06/22/12 17:57:41    /etc/condor/config.d/03-chtc-jobrouter.conf
-06/22/12 17:57:41    /etc/condor/config.d/04-chtc-blacklist.conf
-06/22/12 17:57:41    /etc/condor/config.d/99-osg-ss-group.conf
-06/22/12 17:57:41    /etc/condor/config.d/99-roy-extras.conf
-06/22/12 17:57:41    /etc/condor/condor_config.local
+07/27/22 15:11:46 (D_ALWAYS) ******************************************************
+07/27/22 15:11:46 (D_ALWAYS) ** condor_scheduniv_exec.236889.0 (CONDOR_DAGMAN) STARTING UP
+07/27/22 15:11:46 (D_ALWAYS) ** /usr/bin/condor_dagman
+07/27/22 15:11:46 (D_ALWAYS) ** SubsystemInfo: name=DAGMAN type=DAGMAN(9) class=CLIENT(2)
+07/27/22 15:11:46 (D_ALWAYS) ** Configuration: subsystem:DAGMAN local:<NONE> class:CLIENT
+07/27/22 15:11:46 (D_ALWAYS) ** $CondorVersion: 9.11.0 2022-07-19 BuildID: 597572 PackageID: 9.11.0-0.597572 RC $
+07/27/22 15:11:46 (D_ALWAYS) ** $CondorPlatform: x86_64_CentOS7 $
+07/27/22 15:11:46 (D_ALWAYS) ** PID = 1651969
+07/27/22 15:11:46 (D_ALWAYS) ** Log last touched time unavailable (No such file or directory)
+07/27/22 15:11:46 (D_ALWAYS) ******************************************************
+07/27/22 15:11:46 (D_ALWAYS) Using config source: /etc/condor/condor_config
+07/27/22 15:11:46 (D_ALWAYS) Using local config sources:
+07/27/22 15:11:46 (D_ALWAYS)    /var/run/condor/pids.conf
+07/27/22 15:11:46 (D_ALWAYS)    /var/run/condor/master_pid_6051.conf
+07/27/22 15:11:46 (D_ALWAYS)    /etc/condor/condor_config.principals
+07/27/22 15:11:46 (D_ALWAYS)    /etc/condor/condor_config.hosts
+07/27/22 15:11:46 (D_ALWAYS)    /etc/condor/condor_config.global
+07/27/22 15:11:46 (D_ALWAYS)    /etc/condor/condor_config.policy
+07/27/22 15:11:46 (D_ALWAYS)    /etc/condor/condor_config.x86_64_CentOS7
+07/27/22 15:11:46 (D_ALWAYS)    /etc/condor/condor_config.security
+07/27/22 15:11:46 (D_ALWAYS)    /etc/condor/hosts/learn.chtc.wisc.edu.local
+07/27/22 15:11:46 (D_ALWAYS)    /etc/condor/include/schedd.conf
+07/27/22 15:11:46 (D_ALWAYS)    /etc/condor/include/facility_wid.conf
+07/27/22 15:11:46 (D_ALWAYS)    /etc/condor/include/scitokens_credmon.conf
+07/27/22 15:11:46 (D_ALWAYS)    /etc/condor/include/owned_by_chtc.conf
+07/27/22 15:11:46 (D_ALWAYS)    /var/run/condor/condor_config.startd_offline_gpus
+07/27/22 15:11:46 (D_ALWAYS)    /etc/condor/condor_config.flightworthy_testing
 ```
 Below is where DAGMan realizes that the montage node failed:
 
 ```console
-06/22/12 18:08:42 Event: ULOG_EXECUTE for Condor Node montage (82.0.0)
-06/22/12 18:08:42 Number of idle job procs: 0
-06/22/12 18:08:42 Event: ULOG_IMAGE_SIZE for Condor Node montage (82.0.0)
-06/22/12 18:08:42 Event: ULOG_JOB_TERMINATED for Condor Node montage (82.0.0)
-06/22/12 18:08:42 Node montage job proc (82.0.0) failed with status 1.
-06/22/12 18:08:42 Number of idle job procs: 0
-06/22/12 18:08:42 Of 5 nodes total:
-06/22/12 18:08:42  Done     Pre   Queued    Post   Ready   Un-Ready   Failed
-06/22/12 18:08:42   ===     ===      ===     ===     ===        ===      ===
-06/22/12 18:08:42     4       0        0       0       0          0        1
-06/22/12 18:08:42 0 job proc(s) currently held
-06/22/12 18:08:42 Aborting DAG...
-06/22/12 18:08:42 Writing Rescue DAG to goatbrot.dag.rescue001...
-06/22/12 18:08:42 Note: 0 total job deferrals because of -MaxJobs limit (0)
-06/22/12 18:08:42 Note: 0 total job deferrals because of -MaxIdle limit (0)
-06/22/12 18:08:42 Note: 0 total job deferrals because of node category throttles
-06/22/12 18:08:42 Note: 0 total PRE script deferrals because of -MaxPre limit (0)
-06/22/12 18:08:42 Note: 0 total POST script deferrals because of -MaxPost limit (0)
-06/22/12 18:08:42 **** condor_scheduniv_exec.77.0 (condor_DAGMAN) pid 26867 EXITING WITH STATUS 1
+07/27/22 15:14:12 (D_ALWAYS) Event: ULOG_EXECUTE for HTCondor Node montage (236895.0.0) {07/27/22 15:14:09}
+07/27/22 15:14:12 (D_ALWAYS) Number of idle job procs: 0
+07/27/22 15:14:17 (D_ALWAYS) Currently monitoring 1 HTCondor log file(s)
+07/27/22 15:14:17 (D_ALWAYS) Event: ULOG_JOB_TERMINATED for HTCondor Node montage (236895.0.0) {07/27/22 15:14:13}
+07/27/22 15:14:17 (D_ALWAYS) Number of idle job procs: 0
+07/27/22 15:14:17 (D_ALWAYS) Node montage job proc (236895.0.0) failed with status 1.
+07/27/22 15:14:17 (D_ALWAYS) DAG status: 2 (DAG_STATUS_NODE_FAILED)
+07/27/22 15:14:17 (D_ALWAYS) Of 5 nodes total:
+07/27/22 15:14:17 (D_ALWAYS)  Done     Pre   Queued    Post   Ready   Un-Ready   Failed
+07/27/22 15:14:17 (D_ALWAYS)   ===     ===      ===     ===     ===        ===      ===
+07/27/22 15:14:17 (D_ALWAYS)     4       0        0       0       0          0        1
+07/27/22 15:14:17 (D_ALWAYS) 0 job proc(s) currently held
+07/27/22 15:14:17 (D_ALWAYS) DAGMan Runtime Statistics: [ EventCycleTimeAvg = 0.008020679155985514; EventCycleTimeCount = 30.0; EventCycleTimeMax = 0.1734399795532227; EventCycleTimeMin = 3.790855407714844E-05; EventCycleTimeStd = 0.03267003963035863; EventCycleTimeSum = 0.2406203746795654; LogProcessCycleTimeAvg = 0.001571587153843471; LogProcessCycleTimeCount = 7.0; LogProcessCycleTimeMax = 0.002900123596191406; LogProcessCycleTimeMin = 0.0008997917175292969; LogProcessCycleTimeStd = 0.0006338591087992796; LogProcessCycleTimeSum = 0.0110011100769043; SleepCycleTimeAvg = 5.004259451230367; SleepCycleTimeCount = 30.0; SleepCycleTimeMax = 5.006263017654419; SleepCycleTimeMin = 5.000571966171265; SleepCycleTimeStd = 0.001743289792563769; SleepCycleTimeSum = 150.127783536911; SubmitCycleTimeAvg = 0.007244017816358997; SubmitCycleTimeCount = 31.0; SubmitCycleTimeMax = 0.1727950572967529; SubmitCycleTimeMin = 1.311302185058594E-05; SubmitCycleTimeStd = 0.03207315501357425; SubmitCycleTimeSum = 0.2245645523071289; ]
+07/27/22 15:14:17 (D_ALWAYS) ERROR: the following job(s) failed:
+07/27/22 15:14:17 (D_ALWAYS) ---------------------- Job ----------------------
+07/27/22 15:14:17 (D_ALWAYS)       Node Name: montage
+07/27/22 15:14:17 (D_ALWAYS)            Noop: false
+07/27/22 15:14:17 (D_ALWAYS)          NodeID: 4
+07/27/22 15:14:17 (D_ALWAYS)     Node Status: STATUS_ERROR
+07/27/22 15:14:17 (D_ALWAYS) Node return val: 1
+07/27/22 15:14:17 (D_ALWAYS)           Error: Job proc (236895.0.0) failed with status 1
+07/27/22 15:14:17 (D_ALWAYS) Job Submit File: montage.sub
+07/27/22 15:14:17 (D_ALWAYS)  HTCondor Job ID: (236895.0.0)
+07/27/22 15:14:17 (D_ALWAYS) PARENTS: g1 g2 g3 g4 WAITING: 0 CHILDREN:
+07/27/22 15:14:17 (D_ALWAYS) ---------------------------------------	<END>
+07/27/22 15:14:17 (D_ALWAYS) Aborting DAG...
+07/27/22 15:14:17 (D_ALWAYS) Writing Rescue DAG to goatbrot.dag.rescue001...
+07/27/22 15:14:17 (D_ALWAYS) Removing submitted jobs...
+07/27/22 15:14:17 (D_ALWAYS) Removing any/all submitted HTCondor jobs...
+07/27/22 15:14:17 (D_ALWAYS) Running: /usr/bin/condor_rm -const DAGManJobId==236889
+07/27/22 15:14:17 (D_ALWAYS) Note: 0 total job deferrals because of -MaxJobs limit (0)
+07/27/22 15:14:17 (D_ALWAYS) Note: 0 total job deferrals because of -MaxIdle limit (1000)
+07/27/22 15:14:17 (D_ALWAYS) Note: 0 total job deferrals because of node category throttles
+07/27/22 15:14:17 (D_ALWAYS) Note: 0 total PRE script deferrals because of -MaxPre limit (20) or DEFER
+07/27/22 15:14:17 (D_ALWAYS) Note: 0 total POST script deferrals because of -MaxPost limit (20) or DEFER
+07/27/22 15:14:17 (D_ALWAYS) Note: 0 total HOLD script deferrals because of -MaxHold limit (20) or DEFER
+07/27/22 15:14:17 (D_ALWAYS) DAG status: 2 (DAG_STATUS_NODE_FAILED)
+07/27/22 15:14:17 (D_ALWAYS) Of 5 nodes total:
+07/27/22 15:14:17 (D_ALWAYS)  Done     Pre   Queued    Post   Ready   Un-Ready   Failed
+07/27/22 15:14:17 (D_ALWAYS)   ===     ===      ===     ===     ===        ===      ===
+07/27/22 15:14:17 (D_ALWAYS)     4       0        0       0       0          0        1
+07/27/22 15:14:17 (D_ALWAYS) 0 job proc(s) currently held
+07/27/22 15:14:17 (D_ALWAYS) DAGMan Runtime Statistics: [ EventCycleTimeAvg = 0.008020679155985514; EventCycleTimeCount = 30.0; EventCycleTimeMax = 0.1734399795532227; EventCycleTimeMin = 3.790855407714844E-05; EventCycleTimeStd = 0.03267003963035863; EventCycleTimeSum = 0.2406203746795654; LogProcessCycleTimeAvg = 0.001571587153843471; LogProcessCycleTimeCount = 7.0; LogProcessCycleTimeMax = 0.002900123596191406; LogProcessCycleTimeMin = 0.0008997917175292969; LogProcessCycleTimeStd = 0.0006338591087992796; LogProcessCycleTimeSum = 0.0110011100769043; SleepCycleTimeAvg = 5.004259451230367; SleepCycleTimeCount = 30.0; SleepCycleTimeMax = 5.006263017654419; SleepCycleTimeMin = 5.000571966171265; SleepCycleTimeStd = 0.001743289792563769; SleepCycleTimeSum = 150.127783536911; SubmitCycleTimeAvg = 0.007244017816358997; SubmitCycleTimeCount = 31.0; SubmitCycleTimeMax = 0.1727950572967529; SubmitCycleTimeMin = 1.311302185058594E-05; SubmitCycleTimeStd = 0.03207315501357425; SubmitCycleTimeSum = 0.2245645523071289; ]
+07/27/22 15:14:17 (D_ALWAYS) Wrote metrics file goatbrot.dag.metrics.
+07/27/22 15:14:17 (D_ALWAYS) DAGMan Runtime Statistics: [ EventCycleTimeAvg = 0.008020679155985514; EventCycleTimeCount = 30.0; EventCycleTimeMax = 0.1734399795532227; EventCycleTimeMin = 3.790855407714844E-05; EventCycleTimeStd = 0.03267003963035863; EventCycleTimeSum = 0.2406203746795654; LogProcessCycleTimeAvg = 0.001571587153843471; LogProcessCycleTimeCount = 7.0; LogProcessCycleTimeMax = 0.002900123596191406; LogProcessCycleTimeMin = 0.0008997917175292969; LogProcessCycleTimeStd = 0.0006338591087992796; LogProcessCycleTimeSum = 0.0110011100769043; SleepCycleTimeAvg = 5.004259451230367; SleepCycleTimeCount = 30.0; SleepCycleTimeMax = 5.006263017654419; SleepCycleTimeMin = 5.000571966171265; SleepCycleTimeStd = 0.001743289792563769; SleepCycleTimeSum = 150.127783536911; SubmitCycleTimeAvg = 0.007244017816358997; SubmitCycleTimeCount = 31.0; SubmitCycleTimeMax = 0.1727950572967529; SubmitCycleTimeMin = 1.311302185058594E-05; SubmitCycleTimeStd = 0.03207315501357425; SubmitCycleTimeSum = 0.2245645523071289; ]
+07/27/22 15:14:17 (D_ALWAYS) **** condor_scheduniv_exec.236889.0 (condor_DAGMAN) pid 1651969 EXITING WITH STATUS 1
 ```
 
 DAGMan notices that one of the jobs failed because its exit code was non-zero. DAGMan ran as much of the DAG as possible and logged enough information to continue the run when the situation is resolved. Do you see the part where it wrote the rescue DAG?
@@ -103,7 +136,7 @@ Look at the rescue DAG file. It's called a partial DAG because it indicates what
 username@learn $ cat goatbrot.dag.rescue001
 # Rescue DAG file, created after running
 #   the goatbrot.dag DAG file
-# Created 6/22/2012 23:08:42 UTC
+# Created 7/27/2022 20:14:17 UTC
 # Rescue DAG version: 2.0.1 (partial)
 #
 # Total number of Nodes: 5
@@ -136,109 +169,122 @@ Now we can re-submit our original DAG and DAGMan will pick up where it left off.
 
 ``` console
 username@learn $ condor_submit_dag goatbrot.dag
+
 Running rescue DAG 1
 -----------------------------------------------------------------------
-File for submitting this DAG to Condor           : goatbrot.dag.condor.sub
+File for submitting this DAG to HTCondor           : goatbrot.dag.condor.sub
 Log of DAGMan debugging messages                 : goatbrot.dag.dagman.out
-Log of Condor library output                     : goatbrot.dag.lib.out
-Log of Condor library error messages             : goatbrot.dag.lib.err
+Log of HTCondor library output                     : goatbrot.dag.lib.out
+Log of HTCondor library error messages             : goatbrot.dag.lib.err
 Log of the life of condor_dagman itself          : goatbrot.dag.dagman.log
 
 Submitting job(s).
-1 job(s) submitted to cluster 83.
+1 job(s) submitted to cluster 236903.
 -----------------------------------------------------------------------
 
 username@learn $ tail -f goatbrot.dag.dagman.out
-06/23/12 11:30:53 ******************************************************
-06/23/12 11:30:53 ** condor_scheduniv_exec.83.0 (CONDOR_DAGMAN) STARTING UP
-06/23/12 11:30:53 ** /usr/bin/condor_dagman
-06/23/12 11:30:53 ** SubsystemInfo: name=DAGMAN type=DAGMAN(10) class=DAEMON(1)
-06/23/12 11:30:53 ** Configuration: subsystem:DAGMAN local:<NONE> class:DAEMON
-06/23/12 11:30:53 ** $CondorVersion: 7.7.6 Apr 16 2012 BuildID: 34175 PRE-RELEASE-UWCS $
-06/23/12 11:30:53 ** $CondorPlatform: x86_64_rhap_5.7 $
-06/23/12 11:30:53 ** PID = 28576
-06/23/12 11:30:53 ** Log last touched 6/22 18:08:42
-06/23/12 11:30:53 ******************************************************
-06/23/12 11:30:53 Using config source: /etc/condor/condor_config
+07/27/22 15:35:32 (D_ALWAYS) ******************************************************
+07/27/22 15:35:32 (D_ALWAYS) ** condor_scheduniv_exec.236903.0 (CONDOR_DAGMAN) STARTING UP
+07/27/22 15:35:32 (D_ALWAYS) ** /usr/bin/condor_dagman
+07/27/22 15:35:32 (D_ALWAYS) ** SubsystemInfo: name=DAGMAN type=DAGMAN(9) class=CLIENT(2)
+07/27/22 15:35:32 (D_ALWAYS) ** Configuration: subsystem:DAGMAN local:<NONE> class:CLIENT
+07/27/22 15:35:32 (D_ALWAYS) ** $CondorVersion: 9.11.0 2022-07-19 BuildID: 597572 PackageID: 9.11.0-0.597572 RC $
+07/27/22 15:35:32 (D_ALWAYS) ** $CondorPlatform: x86_64_CentOS7 $
+07/27/22 15:35:32 (D_ALWAYS) ** PID = 1653758
+07/27/22 15:35:32 (D_ALWAYS) ** Log last touched 7/27 15:14:17
+07/27/22 15:35:32 (D_ALWAYS) ******************************************************
+07/27/22 15:35:32 (D_ALWAYS) Using config source: /etc/condor/condor_config
 ...
 ```
 
 <span style="color:RED">**Here is where DAGMAN notices that there is a rescue DAG**</span>
 
 ```hl_lines="3"
-06/23/12 11:30:53 Parsing 1 dagfiles
-06/23/12 11:30:53 Parsing goatbrot.dag ...
-06/23/12 11:30:53 Found rescue DAG number 1; running goatbrot.dag.rescue001 in combination with normal DAG file
-06/23/12 11:30:53 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-06/23/12 11:30:53 USING RESCUE DAG goatbrot.dag.rescue001
-06/23/12 11:30:53 Dag contains 5 total jobs
+07/27/22 15:35:32 (D_ALWAYS) Parsing 1 dagfiles
+07/27/22 15:35:32 (D_ALWAYS) Parsing goatbrot.dag ...
+07/27/22 15:35:32 (D_ALWAYS) Adjusting edges
+07/27/22 15:35:32 (D_ALWAYS) Found rescue DAG number 1; running goatbrot.dag.rescue001 in combination with normal DAG file
+07/27/22 15:35:32 (D_ALWAYS) ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+07/27/22 15:35:32 (D_ALWAYS) USING RESCUE DAG goatbrot.dag.rescue001
+07/27/22 15:35:32 (D_ALWAYS) Dag contains 5 total jobs
 ```
 
 <span style="color:RED">**Shortly thereafter it sees that four jobs have already finished.**</span>
 
 ```console
-06/23/12 11:31:05 Bootstrapping...
-06/23/12 11:31:05 Number of pre-completed nodes: 4
-06/23/12 11:31:05 Registering condor_event_timer...
-06/23/12 11:31:06 Sleeping for one second for log file consistency
-06/23/12 11:31:07 MultiLogFiles: truncating log file /home/roy/condor/goatbrot/montage.log
+07/27/22 15:35:32 (D_ALWAYS) Bootstrapping...
+07/27/22 15:35:32 (D_ALWAYS) Number of pre-completed nodes: 4
+07/27/22 15:35:32 (D_ALWAYS) MultiLogFiles: truncating log file /home/username/osg/workflows/./goatbrot.dag.nodes.log
+07/27/22 15:35:32 (D_ALWAYS) DAG status: 0 (DAG_STATUS_OK)
+07/27/22 15:35:32 (D_ALWAYS) Of 5 nodes total:
+07/27/22 15:35:32 (D_ALWAYS)  Done     Pre   Queued    Post   Ready   Un-Ready   Failed
+07/27/22 15:35:32 (D_ALWAYS)   ===     ===      ===     ===     ===        ===      ===
+07/27/22 15:35:32 (D_ALWAYS)     4       0        0       0       1          0        0
+07/27/22 15:35:32 (D_ALWAYS) 0 job proc(s) currently held
+07/27/22 15:35:32 (D_ALWAYS) DAGMan Runtime Statistics: [ EventCycleTimeCount = 0.0; EventCycleTimeSum = 0.0; LogProcessCycleTimeCount = 0.0; LogProcessCycleTimeSum = 0.0; SleepCycleTimeCount = 0.0; SleepCycleTimeSum = 0.0; SubmitCycleTimeCount = 0.0; SubmitCycleTimeSum = 0.0; ]
+07/27/22 15:35:32 (D_ALWAYS) Registering condor_event_timer...
 ```
 
 <span style="color:RED">**Here is where DAGMan resubmits the montage job and waits for it to complete.**</span>
 
 ```console
-06/23/12 11:31:07 Submitting Condor Node montage job(s)...
-06/23/12 11:31:07 submitting: condor_submit 
-      -a dag_node_name' '=' 'montage 
-      -a +DAGManJobId' '=' '83 
-      -a DAGManJobId' '=' '83 
-      -a submit_event_notes' '=' 'DAG' 'Node:' 'montage 
-      -a DAG_STATUS' '=' '0 
-      -a FAILED_COUNT' '=' '0 
-      -a +DAGParentNodeNames' '=' '"g1,g2,g3,g4" 
-      montage.sub
-06/23/12 11:31:07 From submit: Submitting job(s).
-06/23/12 11:31:07 From submit: 1 job(s) submitted to cluster 84.
-06/23/12 11:31:07   assigned Condor ID (84.0.0)
-06/23/12 11:31:07 Just submitted 1 job this cycle...
-06/23/12 11:31:07 Currently monitoring 1 Condor log file(s)
-06/23/12 11:31:07 Event: ULOG_SUBMIT for Condor Node montage (84.0.0)
-06/23/12 11:31:07 Number of idle job procs: 1
-06/23/12 11:31:07 Of 5 nodes total:
-06/23/12 11:31:07  Done     Pre   Queued    Post   Ready   Un-Ready   Failed
-06/23/12 11:31:07   ===     ===      ===     ===     ===        ===      ===
-06/23/12 11:31:07     4       0        1       0       0          0        0
-06/23/12 11:31:07 0 job proc(s) currently held
-06/23/12 11:40:22 Currently monitoring 1 Condor log file(s)
-06/23/12 11:40:22 Event: ULOG_EXECUTE for Condor Node montage (84.0.0)
-06/23/12 11:40:22 Number of idle job procs: 0
-06/23/12 11:40:22 Event: ULOG_IMAGE_SIZE for Condor Node montage (84.0.0)
-06/23/12 11:40:22 Event: ULOG_JOB_TERMINATED for Condor Node montage (84.0.0)
+07/27/22 15:35:33 (D_ALWAYS) Submitting HTCondor Node montage job(s)...
+07/27/22 15:35:33 (D_ALWAYS) Submitting node montage from file montage.sub using direct job submission
+07/27/22 15:35:33 (D_ALWAYS) Submit warning: Submit:0:the line 'RETRY = 0' was unused by DAGMAN. Is it a typo?
+|Submit:0:the line 'JOB = montage' was unused by DAGMAN. Is it a typo?
+07/27/22 15:35:33 (D_ALWAYS) 	assigned HTCondor ID (236904.0.0)
+07/27/22 15:35:33 (D_ALWAYS) Just submitted 1 job this cycle...
+07/27/22 15:35:33 (D_ALWAYS) DAG status: 0 (DAG_STATUS_OK)
+07/27/22 15:35:33 (D_ALWAYS) Of 5 nodes total:
+07/27/22 15:35:33 (D_ALWAYS)  Done     Pre   Queued    Post   Ready   Un-Ready   Failed
+07/27/22 15:35:33 (D_ALWAYS)   ===     ===      ===     ===     ===        ===      ===
+07/27/22 15:35:33 (D_ALWAYS)     4       0        1       0       0          0        0
+07/27/22 15:35:33 (D_ALWAYS) 0 job proc(s) currently held
+07/27/22 15:35:33 (D_ALWAYS) DAGMan Runtime Statistics: [ EventCycleTimeCount = 0.0; EventCycleTimeSum = 0.0; LogProcessCycleTimeCount = 0.0; LogProcessCycleTimeSum = 0.0; SleepCycleTimeCount = 0.0; SleepCycleTimeSum = 0.0; SubmitCycleTimeAvg = 0.05305004119873047; SubmitCycleTimeCount = 1.0; SubmitCycleTimeMax = 0.05305004119873047; SubmitCycleTimeMin = 0.05305004119873047; SubmitCycleTimeStd = 0.05305004119873047; SubmitCycleTimeSum = 0.05305004119873047; ]
+07/27/22 15:35:38 (D_ALWAYS) Currently monitoring 1 HTCondor log file(s)
+07/27/22 15:35:38 (D_ALWAYS) Reassigning the id of job montage from (236904.0.0) to (236904.0.0)
+07/27/22 15:35:38 (D_ALWAYS) Event: ULOG_SUBMIT for HTCondor Node montage (236904.0.0) {07/27/22 15:35:33}
+07/27/22 15:35:38 (D_ALWAYS) Number of idle job procs: 1
+07/27/22 15:37:29 (D_ALWAYS) Currently monitoring 1 HTCondor log file(s)
+07/27/22 15:37:29 (D_ALWAYS) Event: ULOG_EXECUTE for HTCondor Node montage (236904.0.0) {07/27/22 15:37:28}
+07/27/22 15:37:29 (D_ALWAYS) Number of idle job procs: 0
+07/27/22 15:37:39 (D_ALWAYS) Currently monitoring 1 HTCondor log file(s)
+07/27/22 15:37:39 (D_ALWAYS) Event: ULOG_JOB_TERMINATED for HTCondor Node montage (236904.0.0) {07/27/22 15:37:34}
 ```
 
 <span style="color:RED">**This is where the montage finished.**</span>
 
 ```console
-06/23/12 11:40:22 Node montage job proc (84.0.0) completed successfully.
-06/23/12 11:40:22 Node montage job completed
-06/23/12 11:40:22 Number of idle job procs: 0
-06/23/12 11:40:22 Of 5 nodes total:
-06/23/12 11:40:22  Done     Pre   Queued    Post   Ready   Un-Ready   Failed
-06/23/12 11:40:22   ===     ===      ===     ===     ===        ===      ===
-06/23/12 11:40:22     5       0        0       0       0          0        0
-06/23/12 11:40:22 0 job proc(s) currently held
+07/27/22 15:37:39 (D_ALWAYS) Node montage job proc (236904.0.0) completed successfully.
+07/27/22 15:37:39 (D_ALWAYS) Node montage job completed
+07/27/22 15:37:39 (D_ALWAYS) DAG status: 0 (DAG_STATUS_OK)
+07/27/22 15:37:39 (D_ALWAYS) Of 5 nodes total:
+07/27/22 15:37:39 (D_ALWAYS)  Done     Pre   Queued    Post   Ready   Un-Ready   Failed
+07/27/22 15:37:39 (D_ALWAYS)   ===     ===      ===     ===     ===        ===      ===
+07/27/22 15:37:39 (D_ALWAYS)     5       0        0       0       0          0        0
+07/27/22 15:37:39 (D_ALWAYS) 0 job proc(s) currently held
 ```
 
 <span style="color:RED">**And here DAGMan decides that the work is all done.**</span>
 
 ```console
-06/23/12 11:40:22 All jobs Completed!
-06/23/12 11:40:22 Note: 0 total job deferrals because of -MaxJobs limit (0)
-06/23/12 11:40:22 Note: 0 total job deferrals because of -MaxIdle limit (0)
-06/23/12 11:40:22 Note: 0 total job deferrals because of node category throttles
-06/23/12 11:40:22 Note: 0 total PRE script deferrals because of -MaxPre limit (0)
-06/23/12 11:40:22 Note: 0 total POST script deferrals because of -MaxPost limit (0)
-06/23/12 11:40:22 **** condor_scheduniv_exec.83.0 (condor_DAGMAN) pid 28576 EXITING WITH STATUS 0
+07/27/22 15:37:39 (D_ALWAYS) All jobs Completed!
+07/27/22 15:37:39 (D_ALWAYS) Note: 0 total job deferrals because of -MaxJobs limit (0)
+07/27/22 15:37:39 (D_ALWAYS) Note: 0 total job deferrals because of -MaxIdle limit (1000)
+07/27/22 15:37:39 (D_ALWAYS) Note: 0 total job deferrals because of node category throttles
+07/27/22 15:37:39 (D_ALWAYS) Note: 0 total PRE script deferrals because of -MaxPre limit (20) or DEFER
+07/27/22 15:37:39 (D_ALWAYS) Note: 0 total POST script deferrals because of -MaxPost limit (20) or DEFER
+07/27/22 15:37:39 (D_ALWAYS) Note: 0 total HOLD script deferrals because of -MaxHold limit (20) or DEFER
+07/27/22 15:37:39 (D_ALWAYS) DAG status: 0 (DAG_STATUS_OK)
+07/27/22 15:37:39 (D_ALWAYS) Of 5 nodes total:
+07/27/22 15:37:39 (D_ALWAYS)  Done     Pre   Queued    Post   Ready   Un-Ready   Failed
+07/27/22 15:37:39 (D_ALWAYS)   ===     ===      ===     ===     ===        ===      ===
+07/27/22 15:37:39 (D_ALWAYS)     5       0        0       0       0          0        0
+07/27/22 15:37:39 (D_ALWAYS) 0 job proc(s) currently held
+07/27/22 15:37:39 (D_ALWAYS) DAGMan Runtime Statistics: [ EventCycleTimeAvg = 0.002316570281982422; EventCycleTimeCount = 25.0; EventCycleTimeMax = 0.05394816398620605; EventCycleTimeMin = 3.695487976074219E-05; EventCycleTimeStd = 0.01076852495354839; EventCycleTimeSum = 0.05791425704956055; LogProcessCycleTimeAvg = 0.001371304194132487; LogProcessCycleTimeCount = 3.0; LogProcessCycleTimeMax = 0.002517938613891602; LogProcessCycleTimeMin = 0.0004379749298095703; LogProcessCycleTimeStd = 0.001056260644337736; LogProcessCycleTimeSum = 0.004113912582397461; SleepCycleTimeAvg = 5.005472593307495; SleepCycleTimeCount = 25.0; SleepCycleTimeMax = 5.005934000015259; SleepCycleTimeMin = 5.005262136459351; SleepCycleTimeStd = 0.0002209916994280902; SleepCycleTimeSum = 125.1368148326874; SubmitCycleTimeAvg = 0.002054883883549617; SubmitCycleTimeCount = 26.0; SubmitCycleTimeMax = 0.05305004119873047; SubmitCycleTimeMin = 1.311302185058594E-05; SubmitCycleTimeStd = 0.01040101214466667; SubmitCycleTimeSum = 0.05342698097229004; ]
+07/27/22 15:37:39 (D_ALWAYS) Wrote metrics file goatbrot.dag.metrics.
+07/27/22 15:37:39 (D_ALWAYS) DAGMan Runtime Statistics: [ EventCycleTimeAvg = 0.002316570281982422; EventCycleTimeCount = 25.0; EventCycleTimeMax = 0.05394816398620605; EventCycleTimeMin = 3.695487976074219E-05; EventCycleTimeStd = 0.01076852495354839; EventCycleTimeSum = 0.05791425704956055; LogProcessCycleTimeAvg = 0.001371304194132487; LogProcessCycleTimeCount = 3.0; LogProcessCycleTimeMax = 0.002517938613891602; LogProcessCycleTimeMin = 0.0004379749298095703; LogProcessCycleTimeStd = 0.001056260644337736; LogProcessCycleTimeSum = 0.004113912582397461; SleepCycleTimeAvg = 5.005472593307495; SleepCycleTimeCount = 25.0; SleepCycleTimeMax = 5.005934000015259; SleepCycleTimeMin = 5.005262136459351; SleepCycleTimeStd = 0.0002209916994280902; SleepCycleTimeSum = 125.1368148326874; SubmitCycleTimeAvg = 0.002054883883549617; SubmitCycleTimeCount = 26.0; SubmitCycleTimeMax = 0.05305004119873047; SubmitCycleTimeMin = 1.311302185058594E-05; SubmitCycleTimeStd = 0.01040101214466667; SubmitCycleTimeSum = 0.05342698097229004; ]
+07/27/22 15:37:39 (D_ALWAYS) **** condor_scheduniv_exec.236903.0 (condor_DAGMAN) pid 1653758 EXITING WITH STATUS 0
 ```
 
 Success! Now go ahead and clean up.


### PR DESCRIPTION
The CHTC DAGMan logs are a lot more chatty than in the past. This updates the logs in the exercise so that users have a more recent example to use as reference.